### PR TITLE
Corrected date formatting

### DIFF
--- a/src/public/javascripts/main.ts
+++ b/src/public/javascripts/main.ts
@@ -91,6 +91,9 @@ function getApiData(url: string): Promise<string> {
     });
 }
 
+const timeElement = document.getElementById("time")
+const dateElement = document.getElementById("date")
+
 function startTime() {
     const days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
     const today = new Date();
@@ -102,8 +105,12 @@ function startTime() {
     const year = today.getFullYear();
     const day = days[today.getDay()];
     const hourstr = addZero((hour > 12) ? (hour - 12) : hour);
-    document.getElementById("time").innerHTML = hourstr + ":" + min + ":" + sec;
-    document.getElementById("date").innerHTML = day + "," + month + "/" + date + "/" + year;
+    
+    // set time
+    timeElement.innerHTML = `${hourstr}:${min}:${sec}`;
+    
+    // set date
+    dateElement.innerHTML = `${day}, ${month}/${date}/${year}`;
     setTimeout(startTime, 500);
 }
 


### PR DESCRIPTION
- Corrected date formatting (added missing space that was bugging me.  Example of incorrect formatting: `Wednesday,04/24/2019`).
- Using more modern string interpolation for increased readability.
- Only get date/time DOM elements once (for efficiency), keep a constant reference to each in global scope.